### PR TITLE
fix: Add base path to Astro config for GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,8 @@ import mdx from '@astrojs/mdx';
 import AstroPWA from '@vite-pwa/astro';
 
 export default defineConfig({
-  site: 'https://ThatThadGuy.github.io/AshAboveAshBelow', // Replace with your details
+  site: 'https://ThatThadGuy.github.io/AshAboveAshBelow',
+  base: '/AshAboveAshBelow',
   integrations: [
     tailwind(),
     mdx(),


### PR DESCRIPTION
This commit adds the `base` property to the `astro.config.mjs` file.

This change is necessary for the site to be deployed correctly to a subdirectory on GitHub Pages (e.g., `<username>.github.io/<repo-name>`). Without this setting, asset and page links resolve incorrectly, leading to 404 errors on the live site.

Setting `base: '/AshAboveAshBelow'` ensures that all generated URLs are prefixed with the repository name, allowing all content to load as expected.